### PR TITLE
Add Relative abundance handling to chianti_kev_lines

### DIFF
--- a/sunxspex/chianti_kev_lines.py
+++ b/sunxspex/chianti_kev_lines.py
@@ -141,15 +141,9 @@ def chianti_kev_lines(energy_edges, temperature, emission_measure=1e44/u.cm**3,
     uu = np.log10(mgtemp)
 
     zindex, line_meta, line_properties, line_intensities = chianti_kev_line_common_load(linefile=FILE_IN)
-    line_energies = line_properties["ENERGY"].quantity.to(u.keV)
+    line_energies = line_properties["ENERGY"].quantity.to(u.keV).value
     log10_temp_K_range = line_meta["LOGT_ISOTHERMAL"]
     line_element_indices = line_iz = line_properties["IZ"].data
-    # Location of file giving intensity as a function of temperatures at all line energies:
-    # https://hesperia.gsfc.nasa.gov/ssw/packages/xray/dbase/chianti/chianti_lines_1_10_v71.sav
-    #line_energies, log10_temp_K_range, line_intensities, line_element_indices, element_indices, \
-    #  line_iz = _extract_from_chianti_lines_sav()
-    #energy = (np.linspace(3, 9, 1001) * u.keV).value
-    line_energies = line_energies.value
 
     # Load abundances
     abundance = xr_rd_abundance(abundance_type=kwargs.get("abundance_type", None),
@@ -174,7 +168,6 @@ def chianti_kev_lines(energy_edges, temperature, emission_measure=1e44/u.cm**3,
     out_lines_iz = copy.copy(line_iz)
     sline = copy.copy(line_indices)
     nsline = copy.copy(n_line_indices)
-    #zindex = copy.copy(element_indices)
 
     if n_line_indices > 0:
         eline = eline[sline]

--- a/sunxspex/chianti_kev_lines.py
+++ b/sunxspex/chianti_kev_lines.py
@@ -5,10 +5,12 @@ from collections import OrderedDict
 
 import numpy as np
 import astropy.units as u
+from astropy.table import Table, Column
 import scipy.io
 from scipy.sparse import csr_matrix
 from sunpy.io.special.genx import read_genx
 import sunpy.coordinates
+from sunpy.time import parse_time
 
 SSWDB_XRAY_CHIANTI = os.path.expanduser(os.path.join("~", "ssw", "packages",
                                                      "xray", "dbase", "chianti"))
@@ -129,11 +131,14 @@ def chianti_kev_lines(energy_edges, temperature, emission_measure=1e44/u.cm**3,
     mgtemp = temp * 1e6
     uu = np.log10(mgtemp)
 
-    #zindex, out, totcont, totcont_lo, edge_str, ctemp, chianti_doc = chianti_kev_common_load(linefile=FILE_IN)
+    zindex, line_meta, line_properties, line_intensities, continuum_properties = chianti_kev_common_load(linefile=FILE_IN)
+    line_energies = line_properties["ENERGY"].quantity.to(u.keV)
+    log10_temp_K_range = line_meta["LOGT_ISOTHERMAL"]
+    line_element_indices = line_iz = line_properties["IZ"].data
     # Location of file giving intensity as a function of temperatures at all line energies:
     # https://hesperia.gsfc.nasa.gov/ssw/packages/xray/dbase/chianti/chianti_lines_1_10_v71.sav
-    line_energies, log10_temp_K_range, line_intensities, line_element_indices, element_indices, \
-      line_iz = _extract_from_chianti_lines_sav()
+    #line_energies, log10_temp_K_range, line_intensities, line_element_indices, element_indices, \
+    #  line_iz = _extract_from_chianti_lines_sav()
     #energy = (np.linspace(3, 9, 1001) * u.keV).value
     line_energies = line_energies.value
 
@@ -162,7 +167,7 @@ def chianti_kev_lines(energy_edges, temperature, emission_measure=1e44/u.cm**3,
     out_lines_iz = copy.copy(line_iz)
     sline = copy.copy(line_indices)
     nsline = copy.copy(n_line_indices)
-    zindex = copy.copy(element_indices)
+    #zindex = copy.copy(element_indices)
 
     if n_line_indices > 0:
         eline = eline[sline]
@@ -266,32 +271,46 @@ def chianti_kev_lines(energy_edges, temperature, emission_measure=1e44/u.cm**3,
 
     return spectrum
 
-def chianti_kev_common_load(linefile=None, contfile=None, _extra=None):
+
+def chianti_kev_common_load(linefile=None, contfile=None):
     """
     This procedure is called to load the common blocks that support the chianti_kev... functions.
-
     Parameters
     ----------
-    linefile: 
-
-    contfile:
-
-    no_abund: Not used
-
-    reload: Not used
-
-    _extra:
-
-    
+    linefile: `str`
+        Name and path of file containing the X-ray line info.
+    contfile: `str`
+        Name and path of file containing the X-ray continuum info.
+    Returns
+    -------
+    Returns all outputs form chianti_kev_line_common_load() and chianti_kev_cont_common_load().
     """
-    zindex, out = chianti_kev_line_common_load(linefile, _extra=_extra)
-    zindex, totcont, totcont_lo, edge_str, ctemp, chianti_doc = chianti_kev_cont_common_load(
-            contfile, _extra=_extra)
-    return zindex, out, totcont, totcont_lo, edge_str, ctemp, chianti_doc
+    zindex_line, line_meta, line_properties, line_intensities = chianti_kev_line_common_load(linefile)
+    zindex_cont, continuum_properties = chianti_kev_cont_common_load(contfile)
+    if not all(zindex_line == zindex_cont):
+        raise ValueError("Mismatch between zindex from line and continuum files.")
+    return zindex_line, line_meta, line_properties, line_intensities, continuum_properties
 
-def chianti_kev_line_common_load(file_in=None, _extra=None):
-    line_energies, log10_temp_K_range, line_intensities, line_element_indices,\
-      element_indices, line_element_indices = _extract_from_chianti_lines_sav()
+
+def chianti_kev_line_common_load(file_in=None):
+    """
+    Read X-ray emission line info needed for the chianti_kev_... functions.
+    Parameters
+    ----------
+    file_in: `str`
+        Name of IDL save file containing line info.  If not given it is derived.
+    Returns
+    -------
+    zindex: `numpy.ndarray`
+        Indicies of elements as they appear in periodic table.
+    line_meta: `dict`
+        Various metadata associated with line properties.
+    line_properties: `astropy.table.Table`
+        Various properties of each lines.
+    line_intensities: `astropy.units.Quantity`
+        Intensities of each of the lines in line_properties over a temperature axis.
+        The array is 2D with axes of (line, temperature axis)
+    """
 
     # Define defaults
     if file_in is None:
@@ -313,21 +332,94 @@ def chianti_kev_line_common_load(file_in=None, _extra=None):
         # Read file...
         raise NotImplementedError("Reading .geny file not yet implemented.")
     else:
-        raise ValueError("unrecognized file type: .{0}. Must be .sav or .geny") 
+        raise ValueError("unrecognized file type: .{0}. Must be .sav or .geny")
 
-    # Sort lines in ascending energy.
-    ordd = np.argsort(out["lines"][0]["WVL"])[::-1]
-    for name in out["lines"][0].dtype.names:
-        out["lines"][0][name][:] = out["lines"][0][name][ordd]
+    # Repackage metadata from file.
+    date = []
+    for date_byte in out["DATE"]:
+        date_strings = str(date_byte[3:], 'utf-8').split()
+        date.append(parse_time("{0}-{1}-{2} {3}".format(date_strings[3], date_strings[0],
+                                                        date_strings[1], date_strings[2])))
+    if len(date) == 1:
+        date = date[0]
+    line_meta = {
+        "IONEQ_LOGT": _clean_array_dims(out["IONEQ_LOGT"]),
+        "IONEQ_NAME": _clean_string_dims(out["IONEQ_NAME"]),
+        "IONEQ_REF": _combine_strings(out["IONEQ_REF"]),
+        "WVL_LIMITS": _clean_array_dims(out["WVL_LIMITS"]),
+        "MODEL_FILE": _clean_string_dims(out["MODEL_FILE"]),
+        "MODEL_NAME": _clean_string_dims(out["MODEL_NAME"]),
+        "MODEL_NE": _clean_array_dims(out["MODEL_NE"]),
+        "MODEL_PE": _clean_array_dims(out["MODEL_PE"]),
+        "MODEL_TE": _clean_array_dims(out["MODEL_TE"]),
+        "WVL_UNITS": _clean_units(out["WVL_UNITS"]),
+        "INT_UNITS": _clean_units(out["INT_UNITS"]),
+        "ADD_PROTONS": _clean_array_dims(out["ADD_PROTONS"], dtype=int),
+        "DATE": date,
+        "VERSION": _clean_string_dims(out['VERSION']),
+        "PHOTOEXCITATION": _clean_array_dims(out["PHOTOEXCITATION"], dtype=int),
+        "LOGT_ISOTHERMAL": _clean_array_dims(out["LOGT_ISOTHERMAL"]),
+        "LOGEM_ISOTHERMAL": _clean_array_dims(out["LOGEM_ISOTHERMAL"]),
+        "chianti_doc": _clean_chianti_doc(contents["chianti_doc"])
+        }
+
+    # Repackage out["line"] into a Table with appropriate units.
+    # Create a list of tables to make sure all data in file is captured.
+    # Although only one iteration is expected.
+    line_properties = []
+    line_intensities = []
+    for lines in out["lines"]:
+        line_props = Table()
+        line_props["IZ"] = Column(lines["IZ"], description="Atomic number of ion element.")
+        line_props["ION"] = Column(lines["ION"],
+            description="Integer ionization state in astronomical notation, i.e. ION-1 = negative charge of ion.")
+        line_props["IDENT"] = Column(lines["IDENT"])
+        line_props["IDENT_LATEX"] = Column(lines["IDENT_LATEX"])
+        line_props["SNOTE"] = Column(lines["SNOTE"],
+            description="Ion label in astronomical (roman numeral) notation.")
+        line_props["LVL1"] = Column(lines["LVL1"])
+        line_props["LVL2"] = Column(lines["LVL2"])
+        line_props["TMAX"] = Column(lines["TMAX"])
+        line_props["WVL"] = Column(lines["WVL"], unit=line_meta["WVL_UNITS"])
+        line_props["ENERGY"] = line_props["WVL"].quantity.to(u.keV, equivalencies=u.spectral())
+        line_props["FLAG"] = Column(lines["FLAG"])
+
+        # Sort lines in ascending energy.
+        ordd = np.argsort(np.array(line_props["WVL"]))[::-1]
+        line_props = line_props[ordd]
+
+        # Extract line intensities.
+        lines_int_sorted = lines["INT"][ordd]
+        line_ints = np.empty((lines_int_sorted.shape[0], lines_int_sorted[0].shape[0]), dtype=float)
+        for i in range(line_ints.shape[0]):
+            line_ints[i, :] = lines_int_sorted[i]
+
+        # Enter outputs from this iteration into list.
+        line_properties.append(line_props)
+        line_intensities.append(line_ints)
+
+    # If there is only one element in the line properties, unpack values.
+    if len(out["lines"]) == 1:
+        line_properties = line_properties[0]
+        line_intensities = line_intensities[0]
     
-    return zindex, out
-    
+    return zindex, line_meta, line_properties, line_intensities
     
 
 def chianti_kev_cont_common_load(file_in, _extra=None):
-    line_energies, log10_temp_K_range, line_intensities, line_element_indices,\
-      element_indices, line_element_indices = _extract_from_chianti_lines_sav()
-
+    """
+    Read X-ray continuum emission info needed for the chianti_kev_... functions.
+    Parameters
+    ----------
+    file_in: `str`
+        Name of IDL save file containing continuum info.  If not given it is derived.
+    Returns
+    -------
+    zindex: `numpy.ndarray`
+        Indicies of elements as they appear in periodic table.
+    continuum_properties: `dict`
+        Properties of continuum emission.
+    """
     # Define defaults
     if file_in is None:
         file_in = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont_1_250_v71.sav")
@@ -342,18 +434,25 @@ def chianti_kev_cont_common_load(file_in, _extra=None):
     if file_in.split(".")[-1] == "sav":
         contents = scipy.io.readsav(file_in)
         zindex = contents["zindex"]
-        totcont = contents["totcont"]
-        totcont_lo = contents["totcont_lo"]
-        edge_str = contents["edge_str"]
-        ctemp = contents["ctemp"]
-        chianti_doc = contents["chianti_doc"]
+        edge_str = {
+                "CONVERSION": _clean_array_dims(contents["edge_str"]["CONVERSION"]),
+                "WVL": _clean_array_dims(contents["edge_str"]["WVL"]),
+                "WVLEDGE": _clean_array_dims(contents["edge_str"]["WVLEDGE"])
+                   }
+        continuum_properties = {
+                "totcont": contents["totcont"],
+                "totcont_lo": contents["totcont_lo"],
+                "edge_str": edge_str,
+                "ctemp": contents["ctemp"],
+                "chianti_doc": _clean_chianti_doc(contents["chianti_doc"])
+                               }
     elif file_in.split(".")[-1] == "geny":
         # Read file...
         raise NotImplementedError("Reading .geny file not yet implemented.")
     else:
         raise ValueError("unrecognized file type: .{0}. Must be .sav or .geny")
 
-    return zindex, totcont, totcont_lo, edge_str, ctemp, chianti_doc
+    return zindex, continuum_properties
 
 
 def xr_rd_abundance(abundance_type=None, xr_ab_file=None):
@@ -415,39 +514,6 @@ def read_abundance_genx(filename):
     return output
 
 
-def _extract_from_chianti_lines_sav():
-    """
-    Extracts data from the CHIANTI lines file relevant for chianti_kev_lines function.
-
-    Returns
-    -------
-
-    """
-    # Read file.
-    struct = scipy.io.readsav(FILE_IN)
-    lines = struct["out"]["lines"][0]
-    # Get indices that would sort lines by ascending energy.
-    ordd = np.argsort(lines["WVL"])[::-1]
-    # Extract energy grid for line information.
-    line_energies = (lines["wvl"][ordd] * u.angstrom).to(u.keV, equivalencies=u.spectral())
-    # Extract log10 of temperature grid for line info.
-    log10_temp_K_range = struct["out"]["logt_isothermal"][0]
-    # Extract line intensities.
-    lines_int_sorted = lines["int"][ordd]
-    line_intensities = np.empty((lines_int_sorted.shape[0], lines_int_sorted[0].shape[0]), dtype=float)
-    for i in range(line_intensities.shape[0]):
-        line_intensities[i, :] = lines_int_sorted[i]
-    # line_intensities =* u.
-    # Extract line IZs.
-    line_element_indices = lines["iz"][ordd]
-    # Extract the zindex
-    element_indices = struct["zindex"]
-    
-
-    return line_energies, log10_temp_K_range, line_intensities, line_element_indices,\
-      element_indices, line_element_indices
-
-
 def chianti_kev_getp(line_intensities, sline, logt, mgtemp, nsline):
     """Currently only supports single mgtemp input.  IDL supports array."""
     nltemp = len(logt)
@@ -499,3 +565,67 @@ def get_reverse_indices(x, nbins, min_range=None, max_range=None):
     arrays_bin_indices = (float(nbins)/(max_range - min_range)*(x - min_range)).astype(int)
     bins_array_indices = tuple([np.where(arrays_bin_indices == i)[0] for i in range(nbins)])
     return arrays_bin_indices, bins_array_indices, bin_edges
+
+
+def _clean_array_dims(arr, dtype=None):
+    # Initialize a single array to hold contents of input arr.
+    result = np.empty(list(arr.shape) + list(arr[0].shape))
+    # Combine arrays in arr into single array.
+    for i in range(arr.shape[0]):
+        result[i] = arr[i]
+    # Remove redundant dimensions
+    result = np.squeeze(result)
+    # If result is now unsized, convert to scalar.
+    if result.shape == ():
+        result = result.item()
+        if dtype is not None:
+            dtype(result)
+    return result
+
+
+def _clean_string_dims(arr):
+    result = [str(s, 'utf-8') for s in arr]
+    if len(result) == 1:
+        result = result[0]
+    return result
+
+
+def _combine_strings(arr):
+    result = [".".join([str(ss, 'utf-8') for ss in s]) for s in arr]
+    if len(result) == 1:
+        result = result[0]
+    return result
+
+
+def _clean_units(arr):
+    result = []
+    for a in arr:
+        unit = str(a, 'utf-8')
+        unit_components = unit.split()
+        for i, component in enumerate(unit_components):
+            # Remove plurals
+            if component in ["photons", "Angstroms"]:
+                component = component[:-1]
+            # Insert ** for indices.
+            component_minus_split = component.split("-")
+            if len(component_minus_split) > 1:
+                "**-".join(component_minus_split)
+            component_plus_split = component.split("+")
+            if len(component_plus_split) > 1:
+                "**-".join(component_plus_split)
+            unit_components[i] = component
+        result.append("*".join(unit_components))
+    if len(result) == 1:
+        result = result[0]
+
+    return result
+
+
+def _clean_chianti_doc(arr):
+    chianti_doc = {}
+    chianti_doc["ion_file"] = str(arr[0][0], 'utf-8')
+    chianti_doc["ion_ref"] = "{0}.{1}.{2}".format(str(arr["ion_ref"][0][0], 'utf-8'),
+                                                  str(arr["ion_ref"][0][1], 'utf-8'),
+                                                  str(arr["ion_ref"][0][2], 'utf-8'))
+    chianti_doc["version"] = str(arr[0][2], 'utf-8')
+    return chianti_doc

--- a/sunxspex/chianti_kev_lines.py
+++ b/sunxspex/chianti_kev_lines.py
@@ -140,7 +140,7 @@ def chianti_kev_lines(energy_edges, temperature, emission_measure=1e44/u.cm**3,
     mgtemp = temp * 1e6
     uu = np.log10(mgtemp)
 
-    zindex, line_meta, line_properties, line_intensities, continuum_properties = chianti_kev_common_load(linefile=FILE_IN)
+    zindex, line_meta, line_properties, line_intensities = chianti_kev_line_common_load(linefile=FILE_IN)
     line_energies = line_properties["ENERGY"].quantity.to(u.keV)
     log10_temp_K_range = line_meta["LOGT_ISOTHERMAL"]
     line_element_indices = line_iz = line_properties["IZ"].data
@@ -299,12 +299,12 @@ def chianti_kev_common_load(linefile=None, contfile=None):
     return zindex_line, line_meta, line_properties, line_intensities, continuum_properties
 
 
-def chianti_kev_line_common_load(file_in=None):
+def chianti_kev_line_common_load(linefile=None):
     """
     Read X-ray emission line info needed for the chianti_kev_... functions.
     Parameters
     ----------
-    file_in: `str`
+    linefile: `str`
         Name of IDL save file containing line info.  If not given it is derived.
     Returns
     -------
@@ -320,22 +320,22 @@ def chianti_kev_line_common_load(file_in=None):
     """
 
     # Define defaults
-    if file_in is None:
-        file_in = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_lines_1_10_v71.sav")
-        file_check = glob.glob(file_in)
+    if linefile is None:
+        linefile = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_lines_1_10_v71.sav")
+        file_check = glob.glob(linefile)
         if file_check == []:
-            file_in = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_lines.geny")
-            file_check = glob.glob(file_in)
+            linefile = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_lines.geny")
+            file_check = glob.glob(linefile)
             if file_check == []:
                 raise ValueError("line files not found: {0} or {1}".format(
-                    os.path.join(SSWDB_XRAY_CHIANTI, "chianti_lines_1_10_v71.sav"), file_in))
+                    os.path.join(SSWDB_XRAY_CHIANTI, "chianti_lines_1_10_v71.sav"), linefile))
             
-    if file_in.split(".")[-1] == "sav":
+    if linefile.split(".")[-1] == "sav":
         # Read file
-        contents = scipy.io.readsav(file_in)
+        contents = scipy.io.readsav(linefile)
         zindex = contents["zindex"]
         out = contents["out"]
-    elif file_in.split(".")[-1] == "geny":
+    elif linefile.split(".")[-1] == "geny":
         # Read file...
         raise NotImplementedError("Reading .geny file not yet implemented.")
     else:
@@ -413,12 +413,12 @@ def chianti_kev_line_common_load(file_in=None):
     return zindex, line_meta, line_properties, line_intensities
     
 
-def chianti_kev_cont_common_load(file_in, _extra=None):
+def chianti_kev_cont_common_load(contfile, _extra=None):
     """
     Read X-ray continuum emission info needed for the chianti_kev_... functions.
     Parameters
     ----------
-    file_in: `str`
+    contfile: `str`
         Name of IDL save file containing continuum info.  If not given it is derived.
     Returns
     -------
@@ -428,18 +428,18 @@ def chianti_kev_cont_common_load(file_in, _extra=None):
         Properties of continuum emission.
     """
     # Define defaults
-    if file_in is None:
-        file_in = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont_1_250_v71.sav")
-        file_check = glob.glob(file_in)
+    if contfile is None:
+        contfile = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont_1_250_v71.sav")
+        file_check = glob.glob(contfile)
         if file_check == []:
-            file_in = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont.geny")
-            file_check = glob.glob(file_in)
+            contfile = os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont.geny")
+            file_check = glob.glob(contfile)
             if file_check == []:
                 raise ValueError("line files not found: {0}; {1}".format(
-                    os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont_1_250_v71.sav"), file_in))
+                    os.path.join(SSWDB_XRAY_CHIANTI, "chianti_cont_1_250_v71.sav"), contfile))
     # Read file
-    if file_in.split(".")[-1] == "sav":
-        contents = scipy.io.readsav(file_in)
+    if contfile.split(".")[-1] == "sav":
+        contents = scipy.io.readsav(contfile)
         zindex = contents["zindex"]
         edge_str = {
                 "CONVERSION": _clean_array_dims(contents["edge_str"]["CONVERSION"]),
@@ -453,7 +453,7 @@ def chianti_kev_cont_common_load(file_in, _extra=None):
                 "ctemp": contents["ctemp"],
                 "chianti_doc": _clean_chianti_doc(contents["chianti_doc"])
                                }
-    elif file_in.split(".")[-1] == "geny":
+    elif contfile.split(".")[-1] == "geny":
         # Read file...
         raise NotImplementedError("Reading .geny file not yet implemented.")
     else:

--- a/sunxspex/tests/test_chianit_kev_lines.py
+++ b/sunxspex/tests/test_chianit_kev_lines.py
@@ -11,7 +11,7 @@ energy_edges = np.arange(3, 28.5, 0.5)*u.keV
 
 # Output spectrum from SSW given energy edges from 3 - 28.5 keV in 0.5keV bins with 
 # no relative abundances and not scaled to the observer distance.
-expected_spectrum_E032805_6MK_EM1e44_NoRelAbund_NotObserverScaled = np.array([
+expected_spectrum_E032805_6MK_EM1e44_NoRelAbun_NotObserverScaled = np.array([
     1.6399155e+25, 3.1898577e+24, 9.9494481e+23, 1.5177821e+23, 5.2238873e+21, 5.7652733e+16,
     7.6214856e+21, 4.7918666e+21, 1.1277105e+20, 1.8742482e+15, 6.2098577e+14, 3.4694431e+13,
     4.3706952e+09, 2973542.5,     234939.45,     0.0000000,     0.0000000,     0.0000000,
@@ -22,11 +22,23 @@ expected_spectrum_E032805_6MK_EM1e44_NoRelAbund_NotObserverScaled = np.array([
     0.0000000,     0.0000000,     0.0000000,     0.0000000,     0.0000000,     0.0000000,
     0.0000000,     0.0000000])
 
+expected_spectrum_E032805_6MK_EM1e44_RelAbunFe2_NotObserverScaled = np.array([
+    1.6399155e+25,   3.1898577e+24,   9.9494481e+23,   1.5177821e+23,   5.2238873e+21,   1.1521569e+17,
+    1.5242971e+22,   9.5837332e+21,   2.2554210e+20,   3.7478687e+15,   1.2419604e+15,   6.9386484e+13,
+    4.3706957e+09,   2973542.5,       234939.45,       0.0000000,       0.0000000,       0.0000000,
+    0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,
+    0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,
+    0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,
+    0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,
+    0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,       0.0000000,
+    0.0000000,       0.0000000])
 @pytest.mark.parametrize(
     "energy_edges,temperature,em,relative_abundances,observer_distance,earth,date,expected_spectrum",
     [
         (np.arange(3, 28.5, 0.5)*u.keV, 6*u.MK, default_EM, None, None, None, None,
-        expected_spectrum_E032805_6MK_EM1e44_NoRelAbund_NotObserverScaled)
+        expected_spectrum_E032805_6MK_EM1e44_NoRelAbun_NotObserverScaled),
+        (np.arange(3, 28.5, 0.5)*u.keV, 6*u.MK, default_EM, [(26, 2.0)], None, None, None,
+        expected_spectrum_E032805_6MK_EM1e44_RelAbunFe2_NotObserverScaled)
     ])
 def test_chianti_kev_lines(energy_edges, temperature, em, relative_abundances, 
                            observer_distance, earth, date, expected_spectrum):
@@ -34,4 +46,4 @@ def test_chianti_kev_lines(energy_edges, temperature, em, relative_abundances,
             energy_edges, temperature, em,
             relative_abundances=relative_abundances, observer_distance=observer_distance,
             earth=earth, date=date)
-    np.testing.assert_allclose(output_spectrum[0], expected_spectrum, rtol=0.005, atol=1e-4) # A factor of 2 is currently missing from output spectrum compared to SSW version.
+    np.testing.assert_allclose(output_spectrum[0], expected_spectrum, rtol=0.005, atol=1e-4)


### PR DESCRIPTION
This PR enables users to input relative abundances to ```chianti_kev_lines```.

This PR also replaces ``` _extract_from_chianti_lines_sav``` with an updated version named ```chianti_kev_common_load``` which reads all the data in the line and continuum save files.